### PR TITLE
feat(nvim): add python development support

### DIFF
--- a/nvim/.config/nvim/lua/lsp/mason.lua
+++ b/nvim/.config/nvim/lua/lsp/mason.lua
@@ -35,6 +35,10 @@ return {
         'bash-language-server', -- Bash LSP
         'lua-language-server', -- Lua LSP
         'harper-ls',
+        'pyright', -- Python LSP
+        'ruff', -- Python formatter & linter
+        'ruff-lsp', -- Ruff LSP
+        'debugpy', -- Python DAP
       },
     },
   },
@@ -68,6 +72,8 @@ return {
           'html',
           'cssls',
           'gopls',
+          'pyright',
+          'ruff_lsp',
         },
         automatic_enable = true,
       }

--- a/nvim/.config/nvim/lua/plugins/conform.lua
+++ b/nvim/.config/nvim/lua/plugins/conform.lua
@@ -36,6 +36,7 @@ return {
       typescriptreact = { 'prettier' },
       html = { 'prettier' },
       css = { 'prettier' },
+      python = { 'ruff_format' },
     },
 
     formatters = {

--- a/nvim/.config/nvim/lua/plugins/debug.lua
+++ b/nvim/.config/nvim/lua/plugins/debug.lua
@@ -23,6 +23,7 @@ return {
 
     -- Add your own debuggers here
     'leoluz/nvim-dap-go',
+    'mfussenegger/nvim-dap-python',
 
     {
       'theHamsta/nvim-dap-virtual-text',
@@ -105,6 +106,7 @@ return {
       ensure_installed = {
         -- Update this to ensure that you have the debuggers for the langs you want
         'delve',
+        'debugpy',
       },
     }
 
@@ -145,6 +147,14 @@ return {
     dap.listeners.after.event_initialized['dapui_config'] = dapui.open
     dap.listeners.before.event_terminated['dapui_config'] = dapui.close
     dap.listeners.before.event_exited['dapui_config'] = dapui.close
+
+    require('dap-python').setup 'python'
+
+    dap.adapters.python = {
+      type = 'executable',
+      command = 'uv',
+      args = { 'run', 'python', '-m', 'debugpy.adapter' },
+    }
 
     require('dap.netcore').register_net_dap()
   end,


### PR DESCRIPTION
## Summary
- add Python LSP, formatter, and debug adapters
- integrate ruff formatting and dap-python using uv

## Testing
- `nvim --headless +q` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bedc65c528832785b1fbf68b7092dc