### PR TITLE
feat(nvim): configure pyright to use monorepo venv

### DIFF
--- a/nvim/.config/nvim/lua/lsp/nvim-lspconfig.lua
+++ b/nvim/.config/nvim/lua/lsp/nvim-lspconfig.lua
@@ -3,6 +3,7 @@ return {
   opts = {},
   -----------------------------------------------------[ @LSPCONFIG_CONFIG ]
   config = function()
+    local lspconfig = require 'lspconfig'
     require('lspconfig.ui.windows').default_options.border = 'rounded'
 
     -- Diagnostic Signs
@@ -48,5 +49,16 @@ return {
         -- end, opts)
       end,
     })
+
+    lspconfig.pyright.setup {
+      root_dir = lspconfig.util.root_pattern('uv.lock', 'pyproject.toml', '.git'),
+      on_new_config = function(config, root_dir)
+        config.settings = config.settings or {}
+        config.settings.python = config.settings.python or {}
+        config.settings.python.venvPath = root_dir
+        config.settings.python.pythonPath = root_dir .. '/.venv/bin/python'
+        config.settings.python.venv = '.venv'
+      end,
+    }
   end,
 }


### PR DESCRIPTION
## Summary
- configure nvim lsp for pyright to detect root `.venv`

## Testing
- `nvim --headless +q` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c273cf27508327a03bb75cfce8cf53