### PR TITLE
fix(nvim): ensure pyright uses monorepo venv

### DIFF
--- a/nvim/.config/nvim/lua/lsp/mason.lua
+++ b/nvim/.config/nvim/lua/lsp/mason.lua
@@ -63,7 +63,8 @@ return {
           'github:Crashdummyy/mason-registry',
         },
       }
-      require('mason-lspconfig').setup {
+      local mason_lspconfig = require 'mason-lspconfig'
+      mason_lspconfig.setup {
         ensure_installed = {
           'lua_ls',
           'ts_ls',
@@ -75,40 +76,15 @@ return {
           'pyright',
           'ruff_lsp',
         },
-        automatic_enable = true,
       }
 
-      -- local custom_lsp_configs = {
-      --   -- LUA LANGUAGE SERVER
-      --   lua_ls = {
-      --     settings = {
-      --       Lua = {
-      --         diagnostics = { globals = { 'vim', 'require' } },
-      --         workspace = {
-      --           library = vim.api.nvim_get_runtime_file('', true),
-      --           checkThirdParty = false,
-      --         },
-      --         telemetry = { enable = false },
-      --       },
-      --     },
-      --   },
-      -- }
-      --
-      -- require('mason-lspconfig').setup_handlers {
-      --   function(server_name)
-      --     if custom_lsp_configs[server_name] then
-      --       -- APPLY CUSTOM CONFIG IF EXISTS
-      --       local config = custom_lsp_configs[server_name]
-      --       config.capabilities = capabilities
-      --       require('lspconfig')[server_name].setup(config)
-      --     else
-      --       -- OTHER LANGUAGE SERVER AUTO CONFIG
-      --       require('lspconfig')[server_name].setup {
-      --         capabilities = capabilities,
-      --       }
-      --     end
-      --   end,
-      -- }
+      mason_lspconfig.setup_handlers {
+        function(server_name)
+          if server_name ~= 'pyright' then
+            require('lspconfig')[server_name].setup {}
+          end
+        end,
+      }
 
       require('lspconfig').harper_ls.setup {}
     end,

--- a/nvim/.config/nvim/lua/lsp/nvim-lspconfig.lua
+++ b/nvim/.config/nvim/lua/lsp/nvim-lspconfig.lua
@@ -3,6 +3,7 @@ return {
   opts = {},
   -----------------------------------------------------[ @LSPCONFIG_CONFIG ]
   config = function()
+    local lspconfig = require 'lspconfig'
     require('lspconfig.ui.windows').default_options.border = 'rounded'
 
     -- Diagnostic Signs
@@ -48,5 +49,16 @@ return {
         -- end, opts)
       end,
     })
+
+    lspconfig.pyright.setup {
+      root_dir = lspconfig.util.root_pattern('uv.lock', '.git'),
+      on_new_config = function(config, root_dir)
+        config.settings = config.settings or {}
+        config.settings.python = config.settings.python or {}
+        config.settings.python.venvPath = root_dir
+        config.settings.python.pythonPath = root_dir .. '/.venv/bin/python'
+        config.settings.python.venv = '.venv'
+      end,
+    }
   end,
 }


### PR DESCRIPTION
## Summary
- configure pyright to resolve root using `uv.lock` or `.git`
- prevent mason-lspconfig from auto-starting a second pyright instance

## Testing
- `stylua nvim/.config/nvim/lua/lsp/mason.lua nvim/.config/nvim/lua/lsp/nvim-lspconfig.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y neovim` *(fails: package has no installation candidate)*
- `nvim --headless +q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c273cf27508327a03bb75cfce8cf53